### PR TITLE
Add link to data at top of website

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,11 +56,9 @@
     </p>
 
     <p class="centered">
-      <!--
-      <a class="pill-button" href="">
+      <a class="pill-button" href="https://huggingface.co/datasets/imageomics/TreeOfLife-10M">
         <img src="images/icons/huggingface.svg" /> Data
       </a>
-      -->
       <a class="pill-button" href="https://huggingface.co/imageomics/bioclip">
         <img src="images/icons/huggingface.svg" /> Models
       </a>


### PR DESCRIPTION
This adds in the link to TreeOfLife-10M so there is a link to the dataset on the website.

I used the commented-out code for "Data" which came first, but we can change the order if the preference is actually to lead with the link to the model(s).