### PR TITLE
Update gradio version for embedded demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
     </p>
         
     <h3>Demo</h3>
-    <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/4.36.1/gradio.js"></script>
+    <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/5.33.0/gradio.js"></script>
     <gradio-app src="https://imageomics-bioclip-demo.hf.space"></gradio-app>
 
     <h2 class="banded" id="evaluation">Experiments</h2>


### PR DESCRIPTION
We updated the Gradio SDK in the [BioCLIP demo](https://huggingface.co/spaces/imageomics/bioclip-demo/commit/33994d93cc5c218868ac94b1f988448ed9fed35f) to fix the "No API found" error. This updates the version called in the embedded demo.