### PR TITLE
Revert "Fix logit scale calculation in zero_shot_iid.py"

### DIFF
--- a/src/evaluation/zero_shot_iid.py
+++ b/src/evaluation/zero_shot_iid.py
@@ -85,7 +85,7 @@ def run(model, classifier, dataloader, args):
                 image_features = model.encode_image(images)
                 image_features = F.normalize(image_features, dim=-1)
                 # logits = 100.0 * image_features @ classifier
-                logits = model.logit_scale * image_features @ classifier
+                logits = model.logit_scale.exp() * image_features @ classifier
 
             # measure accuracy
             acc = accuracy(logits, target, topk=topk.keys())


### PR DESCRIPTION
Reverts Imageomics/bioclip#39

Jianyang mentioned that exp() only happens in forward function. And I noticed that `model.logit_scale` depends on if `self.logit_scale` in `model.py` has been updated to 'logit_scale.exp()`, but it is actually not updated. So, actually, the original code is correct. I am trying to recover it. Thanks for Jianyang's digging.

And theoretically it should not make the ranking different, but numerically, it scales the image features before the matrix multiplication because `model.logit_scale.exp() * image_features @ classifier` is calculated from left to right, as `(model.logit_scale.exp() * image_features) @ classifier`. Then, it will change rounding behavior. If class scores are very close, this can change the ranking.

In conclusion, we should not change the code and the original is actually correct. I will revert my update.